### PR TITLE
Allow CLI to use absolute paths

### DIFF
--- a/packages/heml/src/bin/commands/build.js
+++ b/packages/heml/src/bin/commands/build.js
@@ -9,8 +9,8 @@ const successBlock = chalk.bgGreen.black
 const { log } = console
 
 export default async function build (file, options) {
-  const filepath = path.resolve(process.cwd(), file)
-  const outputpath = path.resolve(process.cwd(), options.output || file.replace(/\.heml$/, '.html'))
+  const filepath = path.resolve(file)
+  const outputpath = path.resolve(options.output || file.replace(/\.heml$/, '.html'))
 
   /** require .heml extention */
   if (!isHemlFile(file)) {

--- a/packages/heml/src/bin/commands/build.js
+++ b/packages/heml/src/bin/commands/build.js
@@ -9,8 +9,8 @@ const successBlock = chalk.bgGreen.black
 const { log } = console
 
 export default async function build (file, options) {
-  const filepath = path.join(process.cwd(), file)
-  const outputpath = path.join(process.cwd(), options.output || file.replace(/\.heml$/, '.html'))
+  const filepath = path.resolve(process.cwd(), file)
+  const outputpath = path.resolve(process.cwd(), options.output || file.replace(/\.heml$/, '.html'))
 
   /** require .heml extention */
   if (!isHemlFile(file)) {

--- a/packages/heml/src/bin/commands/develop.js
+++ b/packages/heml/src/bin/commands/develop.js
@@ -15,7 +15,7 @@ const errorBlock = chalk.bgRed.white
 const { log } = console
 
 export default async function develop (file, options) {
-  const filepath = path.resolve(process.cwd(), file)
+  const filepath = path.resolve(file)
   const {
     port = 3000,
     open = false

--- a/packages/heml/src/bin/commands/develop.js
+++ b/packages/heml/src/bin/commands/develop.js
@@ -15,7 +15,7 @@ const errorBlock = chalk.bgRed.white
 const { log } = console
 
 export default async function develop (file, options) {
-  const filepath = path.join(process.cwd(), file)
+  const filepath = path.resolve(process.cwd(), file)
   const {
     port = 3000,
     open = false


### PR DESCRIPTION
At the moment the CLI only works with relative paths to the working directory. This PR changes the CLI to use `path.resolve` instead of `path.join` so it works with both relative or absolute paths.

See #18 for more.