### PR TITLE
Small packages fixes

### DIFF
--- a/packages/heml-elements/package-lock.json
+++ b/packages/heml-elements/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heml/elements",
-  "version": "1.0.0",
+  "version": "1.0.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12,6 +12,20 @@
         "follow-redirects": "1.2.5",
         "is-buffer": "1.1.5"
       }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "debug": {
       "version": "2.6.9",
@@ -53,6 +67,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     }
   }
 }

--- a/packages/heml-elements/package.json
+++ b/packages/heml-elements/package.json
@@ -24,6 +24,7 @@
     "@heml/styles": "^1.0.2-0",
     "@heml/utils": "^1.0.2-0",
     "axios": "^0.17.0",
+    "babel-runtime": "^6.26.0",
     "image-size": "^0.6.1",
     "is-absolute-url": "^2.1.0",
     "lodash": "^4.17.4"

--- a/packages/heml-inline/package-lock.json
+++ b/packages/heml-inline/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "@heml/inline",
+  "version": "1.0.2-0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "ajv": {
       "version": "5.2.3",
@@ -62,6 +64,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -145,6 +156,11 @@
       "requires": {
         "graceful-readlink": "1.0.1"
       }
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -626,6 +642,11 @@
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
     "request": {
       "version": "2.83.0",

--- a/packages/heml-inline/package.json
+++ b/packages/heml-inline/package.json
@@ -21,6 +21,7 @@
     "access": "public"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "juice": "^4.2.0",
     "lodash": "^4.17.4"
   }

--- a/packages/heml-parse/package-lock.json
+++ b/packages/heml-parse/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heml/parse",
-  "version": "1.0.0",
+  "version": "1.0.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,15 @@
       "version": "6.0.89",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.89.tgz",
       "integrity": "sha512-Z/67L97+6H1qJiEEHSN1SQapkWjDss1D90rAnFcQ6UxKkah9juzotK5UNEP1bDv/0lJ3NAQTnVfc/JWdgCGruA=="
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
     },
     "boolbase": {
       "version": "1.0.0",
@@ -26,6 +35,11 @@
         "lodash": "4.17.4",
         "parse5": "3.0.2"
       }
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -163,6 +177,11 @@
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/packages/heml-parse/package.json
+++ b/packages/heml-parse/package.json
@@ -21,6 +21,7 @@
     "access": "public"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "cheerio": "^1.0.0-rc.2",
     "crypto-random-string": "^1.0.0",
     "html-tags": "^2.0.0",

--- a/packages/heml-render/package-lock.json
+++ b/packages/heml-render/package-lock.json
@@ -1,7 +1,23 @@
 {
-  "requires": true,
+  "name": "@heml/render",
+  "version": "1.0.2-0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+    },
     "escape-goat": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-1.3.0.tgz",
@@ -21,6 +37,11 @@
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
     "stringify-attributes": {
       "version": "1.0.0",

--- a/packages/heml-render/package.json
+++ b/packages/heml-render/package.json
@@ -21,6 +21,7 @@
     "access": "public"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "html-tags": "^2.0.0",
     "is-promise": "^2.1.0",
     "lodash": "^4.17.4",

--- a/packages/heml-styles/package-lock.json
+++ b/packages/heml-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heml/styles",
-  "version": "1.0.0",
+  "version": "1.0.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -116,11 +116,6 @@
         }
       }
     },
-    "css-shorthand-properties": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.0.0.tgz",
-      "integrity": "sha1-VnvmcRA2ebmqBaSBVeUUdLJ1h38="
-    },
     "css-unit-converter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
@@ -211,14 +206,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
       "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
-    },
-    "is-css-shorthand": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-css-shorthand/-/is-css-shorthand-1.0.1.tgz",
-      "integrity": "sha1-MPldAyEGBf7f3RKOU9rEpEN6kzw=",
-      "requires": {
-        "css-shorthand-properties": "1.0.0"
-      }
     },
     "js-base64": {
       "version": "2.3.2",
@@ -1326,71 +1313,6 @@
         "flatten": "1.0.2",
         "indexes-of": "1.0.1",
         "uniq": "1.0.1"
-      }
-    },
-    "postcss-shorthand-expand": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-shorthand-expand/-/postcss-shorthand-expand-1.0.1.tgz",
-      "integrity": "sha1-+DCbWBIN5GdtEghiC6LYgIMPiXg=",
-      "requires": {
-        "css-shorthand-expand": "1.1.0",
-        "is-css-shorthand": "1.0.1",
-        "postcss": "5.2.18"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            }
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-          "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        }
       }
     },
     "postcss-unique-selectors": {

--- a/packages/heml-styles/package-lock.json
+++ b/packages/heml-styles/package-lock.json
@@ -27,6 +27,15 @@
       "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.4.tgz",
       "integrity": "sha1-PrTWEpc/xrbcbvM49W91nyrFw6Y="
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
     "browserslist": {
       "version": "1.7.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
@@ -74,6 +83,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -1401,6 +1415,11 @@
         "css-unit-converter": "1.1.1",
         "postcss-value-parser": "3.3.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
     "repeat-element": {
       "version": "1.1.2",

--- a/packages/heml-styles/package.json
+++ b/packages/heml-styles/package.json
@@ -21,6 +21,7 @@
     "access": "public"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "css-declaration-sorter": "^2.1.0",
     "css-shorthand-expand": "^1.1.0",
     "lodash": "^4.17.4",

--- a/packages/heml-styles/package.json
+++ b/packages/heml-styles/package.json
@@ -49,7 +49,7 @@
     "postcss-ordered-values": "^2.2.3",
     "postcss-rgba-hex": "^0.3.7",
     "postcss-safe-parser": "^3.0.1",
-    "postcss-shorthand-expand": "^1.0.1",
+    "postcss-selector-parser": "^2.2.3",
     "postcss-unique-selectors": "^2.0.2"
   }
 }

--- a/packages/heml-utils/package-lock.json
+++ b/packages/heml-utils/package-lock.json
@@ -1,7 +1,23 @@
 {
-	"requires": true,
+	"name": "@heml/utils",
+	"version": "1.0.2-0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "2.5.1",
+				"regenerator-runtime": "0.11.0"
+			}
+		},
+		"core-js": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+			"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+		},
 		"css-groups": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/css-groups/-/css-groups-0.1.1.tgz",
@@ -11,6 +27,11 @@
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
 			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+		},
+		"regenerator-runtime": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+			"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
 		}
 	}
 }

--- a/packages/heml-utils/package.json
+++ b/packages/heml-utils/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@heml/render": "^1.0.2-0",
+    "babel-runtime": "^6.26.0",
     "css-groups": "^0.1.1",
     "lodash": "^4.17.4"
   }

--- a/packages/heml-validate/package-lock.json
+++ b/packages/heml-validate/package-lock.json
@@ -1,11 +1,32 @@
 {
-  "requires": true,
+  "name": "@heml/validate",
+  "version": "1.0.2-0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+    },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     }
   }
 }

--- a/packages/heml-validate/package.json
+++ b/packages/heml-validate/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@heml/utils": "^1.0.2-0",
+    "babel-runtime": "^6.26.0",
     "lodash": "^4.17.4"
   }
 }


### PR DESCRIPTION
There was an unused package (`postcss-shorthand-expand`) and a used package that was installed by a dependency (`postcss-selector-parser`) that should have been installed.

I also installed `babel-runtime` to all the packages since they could be installed independently of the main `heml` package.