### PR TITLE
Fixing encoded quotes

### DIFF
--- a/packages/heml-render/package.json
+++ b/packages/heml-render/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "html-tags": "^2.0.0",
     "is-promise": "^2.1.0",
-    "lodash": "^4.17.4",
-    "stringify-attributes": "^1.0.0"
+    "lodash": "^4.17.4"
   }
 }

--- a/packages/heml-render/src/createHtmlElement.js
+++ b/packages/heml-render/src/createHtmlElement.js
@@ -1,0 +1,10 @@
+import stringifyAttributes from './stringifyAttributes'
+import selfClosingHtmlTags from 'html-tags/void'
+
+export default function createHtmlElement ({ name, attrs, contents = ' ' }) {
+  if (selfClosingHtmlTags.includes(name)) {
+    return `<${name}${attrs ? stringifyAttributes(attrs) : ''} />`
+  }
+
+  return `<${name}${attrs ? stringifyAttributes(attrs) : ''}>${contents || ' '}</${name}>`
+}

--- a/packages/heml-render/src/renderElement.js
+++ b/packages/heml-render/src/renderElement.js
@@ -1,7 +1,6 @@
-import stringifyAttributes from 'stringify-attributes'
 import isPromise from 'is-promise'
 import { isPlainObject, defaults, mapValues, castArray, compact, flattenDeep } from 'lodash'
-import selfClosingHtmlTags from 'html-tags/void'
+import createHtmlElement from './createHtmlElement'
 
 export default function (name, attrs, ...contents) {
   /** catch all promises in this content and wait for them to finish */
@@ -56,9 +55,5 @@ function render (name, attrs, contents) {
   if (attrs && attrs.class === '') { delete attrs.class }
   if (attrs && attrs.class) { attrs.class = attrs.class.trim() }
 
-  if (selfClosingHtmlTags.includes(name)) {
-    return `<${name}${attrs ? stringifyAttributes(attrs) : ''} />`
-  }
-
-  return `<${name}${attrs ? stringifyAttributes(attrs) : ''}>${contents || ' '}</${name}>`
+  return createHtmlElement({ name, attrs, contents })
 }

--- a/packages/heml-render/src/stringifyAttributes.js
+++ b/packages/heml-render/src/stringifyAttributes.js
@@ -1,0 +1,16 @@
+/** escapeless version of npmjs.com/stringify-attributes */
+export default function stringifyAttributes (attrsObj) {
+  const attributes = []
+
+  for (let [ key, value ] of Object.entries(attrsObj)) {
+    if (value === false) { continue }
+
+    if (Array.isArray(value)) { value = value.join(' ') }
+
+    value = value === true ? '' : `="${String(value)}"`
+
+    attributes.push(`${key}${value}`)
+  }
+
+  return attributes.length > 0 ? ' ' + attributes.join(' ') : ''
+}


### PR DESCRIPTION
This is a potential fix for #32 

The issue is stemming from the [`stringify-attributes`](https://www.npmjs.com/package/stringify-attributes). It currently escapes the attributes and doesn't provide a way to turn that off. This pull that functionality into the heml code base and strips the escaping functionality.