### PR TITLE
catching error in optimistic code

### DIFF
--- a/packages/heml-styles/src/plugins/postcss-expand-shorthand/index.js
+++ b/packages/heml-styles/src/plugins/postcss-expand-shorthand/index.js
@@ -6,6 +6,8 @@ export default postcss.plugin('postcss-expand-shorthand', () => (root) => {
     if (shouldExpand(decl.prop) && !!decl.value) {
       const expandedDecls = shorthandExpand(decl.prop, decl.value)
 
+      if (!expandedDecls) { return }
+
       for (const [ prop, value ] of Object.entries(expandedDecls)) {
         decl.before(postcss.decl({ prop, value }))
       }


### PR DESCRIPTION
Right now if you have a CSS error in a rule that gets expanded (`background`, `margin`, etc.) it will fail and return `undefined`. This is a simple fix to drop out early if the expander returns a falsey value.

You can test this by using a color name that doesn't exist.
```html
<heml>
  <head>
    <style>
      body {
        background: idontexist;
      }
    </style>
  </head>
  <body></body>
</heml>

```