### PR TITLE
check that the command isn't actually a flag

### DIFF
--- a/packages/heml/src/bin/heml.js
+++ b/packages/heml/src/bin/heml.js
@@ -27,7 +27,7 @@ cli
   .option('-v, --validate [level]', 'Sets the validation level', /^(none|soft|strict)$/i, 'soft')
   .action(build)
 
-if (args.length === 0 || !commands.includes(first(args))) {
+if (args.length === 0 || !commands.includes(first(args)) && !first(args).startsWith('-')) {
   cli.outputHelp()
 }
 


### PR DESCRIPTION
Right now if you run `heml -V` it will print out the help command since `-V` isn't in the array of known commands.
```
  Usage:  <command> [options]


  Options:

    -V, --version  output the version number
    -h, --help     output usage information


  Commands:

    develop [options] <file>  Develop your email locally.
    build [options] <file>    Build an HEML email for sending in the wild.
1.1.3
````

This will only output the help if it is an unknown command (and not a flag)