### PR TITLE
Preprocess css

### DIFF
--- a/packages/heml-elements/package-lock.json
+++ b/packages/heml-elements/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heml/elements",
-  "version": "1.0.0",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20,6 +20,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "follow-redirects": {
       "version": "1.2.5",

--- a/packages/heml-elements/package.json
+++ b/packages/heml-elements/package.json
@@ -24,6 +24,7 @@
     "@heml/styles": "^1.1.2",
     "@heml/utils": "^1.1.2",
     "axios": "^0.17.0",
+    "escape-string-regexp": "^1.0.5",
     "image-size": "^0.6.1",
     "is-absolute-url": "^2.1.0",
     "lodash": "^4.17.4"

--- a/packages/heml-elements/src/Base.js
+++ b/packages/heml-elements/src/Base.js
@@ -1,10 +1,10 @@
-import HEML, { createElement } from '@heml/utils' // eslint-disable-line no-unused-vars
+import HEML, { createMetaElement } from '@heml/utils' // eslint-disable-line no-unused-vars
 import Meta from './Meta'
 import isAbsoluteUrl from 'is-absolute-url'
 import { resolve } from 'url'
 import { has, first } from 'lodash'
 
-export default createElement('base', {
+export default createMetaElement('base', {
   parent: [ 'head' ],
   children: false,
   unique: true,

--- a/packages/heml-elements/src/Block.js
+++ b/packages/heml-elements/src/Block.js
@@ -1,5 +1,4 @@
 import HEML, { createElement, transforms, cssGroups, condition } from '@heml/utils' // eslint-disable-line no-unused-vars
-import Style from './Style'
 
 const {
   trueHide,
@@ -31,6 +30,10 @@ export default createElement('block', {
     '.block__cell': [ { '@pseudo': 'cell' }, height, background, box, padding, border, borderRadius, 'vertical-align' ]
   },
 
+  css (Style) {
+    return <Style>{` block { width: 100%; } `}</Style>
+  },
+
   render (attrs, contents) {
     attrs.class += ' block'
     return (
@@ -42,11 +45,6 @@ export default createElement('block', {
           </tr>
         </table>
         {condition('mso | IE', `</td></tr></table>`)}
-        <Style for='block'>{`
-          block {
-            width: 100%;
-          }
-        `}</Style>
       </div>
     )
   }

--- a/packages/heml-elements/src/Body.js
+++ b/packages/heml-elements/src/Body.js
@@ -1,5 +1,4 @@
 import HEML, { createElement, transforms, cssGroups } from '@heml/utils' // eslint-disable-line no-unused-vars
-import Style from './Style'
 import Preview from './Preview'
 
 const {
@@ -23,6 +22,19 @@ export default createElement('body', {
     '.preview': [ { 'background-color': transforms.convertProp('color') } ]
   },
 
+  css (Style) {
+    return <Style>{`
+      body {
+        margin: 0;
+        width: 100%;
+        font-family: Helvetica, Arial, sans-serif;
+        font-size: 16px;
+        line-height: 20px;
+        color: black;
+      }
+    `}</Style>
+  },
+
   async render (attrs, contents) {
     attrs.class += ' body'
 
@@ -35,16 +47,6 @@ export default createElement('body', {
           </tr>
         </table>
         <div style='display:none; white-space:nowrap; font-size:15px; line-height:0;'>{'&nbsp; '.repeat(30)}</div>
-        <Style for='body'>{`
-          body {
-            margin: 0;
-            width: 100%;
-            font-family: Helvetica, Arial, sans-serif;
-            font-size: 16px;
-            line-height: 20px;
-            color: black;
-          }
-      `}</Style>
       </body>)
   }
 })

--- a/packages/heml-elements/src/Button.js
+++ b/packages/heml-elements/src/Button.js
@@ -1,6 +1,5 @@
 import HEML, { createElement, transforms, cssGroups } from '@heml/utils' // eslint-disable-line no-unused-vars
 import { omit, pick } from 'lodash'
-import Style from './Style'
 
 const {
   background,
@@ -37,6 +36,19 @@ export default createElement('button', {
       { '@pseudo': 'text' }, 'color', 'text-decoration' ]
   },
 
+  css (Style) {
+    return <Style>{`
+      button {
+        margin: auto;
+        border-radius: 3px;
+        padding: 6px 12px;
+        background-color: #2097e4;
+        color: #ffffff;
+        text-decoration: none;
+      }
+    `}</Style>
+  },
+
   render (attrs, contents) {
     attrs.class += ' button'
 
@@ -57,16 +69,6 @@ export default createElement('button', {
             </td>
           </tr>
         </table>
-        <Style for='button'>{`
-          button {
-            margin: auto;
-            border-radius: 3px;
-            padding: 6px 12px;
-            background-color: #2097e4;
-            color: #ffffff;
-            text-decoration: none;
-          }
-        `}</Style>
       </div>)
   }
 })

--- a/packages/heml-elements/src/Column.js
+++ b/packages/heml-elements/src/Column.js
@@ -1,5 +1,5 @@
 import HEML, { createElement, transforms, cssGroups } from '@heml/utils' // eslint-disable-line no-unused-vars
-import Style from './Style'
+import { times } from 'lodash'
 
 const {
   background,
@@ -20,6 +20,20 @@ export default createElement('column', {
     '.column': [ { '@pseudo': 'root' }, { display: transforms.trueHide(undefined, true) }, background, box, padding, border, borderRadius, 'vertical-align' ]
   },
 
+  css (Style) {
+    return <Style heml-embed>{`
+       @media only screen and (max-width: ${breakpoint}px) {
+        .column, .column-filler { float: left; box-sizing: border-box; }
+        ${times(12, (i) => `
+        .col-sm-${i+1} {
+          width: ${Math.round((100 * (i+1)) / 12)}% !important;
+          display: block;
+        }
+        `)}
+      }
+    `}</Style>
+  },
+
   render (attrs, contents) {
     const small = parseInt(attrs.small, 10)
     const large = parseInt(attrs.large, 10)
@@ -29,19 +43,9 @@ export default createElement('column', {
     delete attrs.large
     delete attrs.small
 
-    return ([
+    return (
       <td {...attrs} width={largeWidth} style={`width: ${largeWidth};`} align='left' valign='top'>
         {contents.length === 0 ? '&nbsp;' : contents}
-      </td>,
-      small === large ? '' : (<Style for='column' heml-embed>{`
-         @media only screen and (max-width: ${breakpoint}px) {
-          .column, .column-filler { float: left; box-sizing: border-box; }
-          .col-sm-${small} {
-            width: ${Math.round((100 * small) / 12)}% !important;
-            display: block;
-          }
-        }
-      `}</Style>)
-    ])
+      </td>)
   }
 })

--- a/packages/heml-elements/src/Container.js
+++ b/packages/heml-elements/src/Container.js
@@ -1,5 +1,4 @@
 import HEML, { createElement, transforms, cssGroups, condition } from '@heml/utils' // eslint-disable-line no-unused-vars
-import Style from './Style'
 
 const {
   trueHide,
@@ -31,6 +30,16 @@ export default createElement('container', {
     '.container__cell': [ { '@pseudo': 'cell' }, height, background, box, padding, border, borderRadius ]
   },
 
+  css (Style) {
+    return <Style>{`
+      container {
+        max-width: 600px;
+        width: 100%;
+        margin: auto;
+      }
+    `}</Style>
+  },
+
   render (attrs, contents) {
     attrs.class += ' container'
     return (
@@ -42,13 +51,6 @@ export default createElement('container', {
           </tr>
         </table>
         {condition('mso | IE', `</td></tr></table>`)}
-        <Style for='container'>{`
-          container {
-            max-width: 600px;
-            width: 100%;
-            margin: auto;
-          }
-        `}</Style>
       </div>
     )
   }

--- a/packages/heml-elements/src/Head.js
+++ b/packages/heml-elements/src/Head.js
@@ -1,6 +1,5 @@
 import HEML, { createElement } from '@heml/utils' // eslint-disable-line no-unused-vars
 import Subject from './Subject'
-import Style from './Style'
 
 export default createElement('head', {
   unique: true,

--- a/packages/heml-elements/src/Head.js
+++ b/packages/heml-elements/src/Head.js
@@ -48,8 +48,6 @@ export default createElement('head', {
       </style>
       <![endif]-->`}
         <title>{Subject.flush()}</title>
-        {await Style.flush()}
-        {`<!-- content -->`}
         {/* drop in the contents */
       contents}
         {/* https://litmus.com/community/discussions/151-mystery-solved-dpi-scaling-in-outlook-2007-2013 */

--- a/packages/heml-elements/src/Hr.js
+++ b/packages/heml-elements/src/Hr.js
@@ -1,5 +1,4 @@
 import HEML, { createElement, transforms, cssGroups, condition } from '@heml/utils' // eslint-disable-line no-unused-vars
-import Style from './Style'
 
 const {
   trueHide,
@@ -31,6 +30,17 @@ export default createElement('hr', {
     '.hr__cell': [ { '@pseudo': 'cell' }, height, background, box, padding, border, borderRadius, 'vertical-align' ]
   },
 
+  css (Style) {
+    return <Style>{`
+      hr {
+        width: 100%;
+        margin: auto;
+        border-top: 1px solid #9A9A9A;
+      }
+    `}</Style>
+  },
+
+
   render (attrs, contents) {
     attrs.class += ' hr'
     return (
@@ -42,13 +52,6 @@ export default createElement('hr', {
           </tr>
         </table>
         {condition('mso | IE', `</td></tr></table>`)}
-        <Style for='hr'>{`
-          hr {
-            width: 100%;
-            margin: auto;
-            border-top: 1px solid #9A9A9A;
-          }
-        `}</Style>
       </div>
     )
   }

--- a/packages/heml-elements/src/Img.js
+++ b/packages/heml-elements/src/Img.js
@@ -1,5 +1,4 @@
 import HEML, { createElement, transforms } from '@heml/utils' // eslint-disable-line no-unused-vars
-import Style from './Style'
 import { omit, has } from 'lodash'
 import fs from 'fs-extra'
 import isAbsoluteUrl from 'is-absolute-url'
@@ -18,6 +17,15 @@ export default createElement('img', {
     'img': [ { '@pseudo': 'root' }, { display: transforms.trueHide() }, '@default' ]
   },
 
+  css (Style) {
+    return <Style>{`
+      .img__block {
+        display: block;
+        max-width: 100%;
+      }
+    `}</Style>
+  },
+
   async render (attrs, contents) {
     const isBlock = !attrs.inline
 
@@ -28,14 +36,7 @@ export default createElement('img', {
     attrs.class += ` ${isBlock ? 'img__block' : 'img__inline'}`
     attrs.style = isBlock ? '' : 'display: inline-block;'
 
-    return ([
-      <img {...omit(attrs, 'inline', 'infer')} />,
-      <Style for='img'>{`
-        .img__block {
-          display: block;
-          max-width: 100%;
-        }
-      `}</Style>])
+    return <img {...omit(attrs, 'inline', 'infer')} />
   }
 })
 

--- a/packages/heml-elements/src/Meta.js
+++ b/packages/heml-elements/src/Meta.js
@@ -1,8 +1,8 @@
-import HEML, { createElement } from '@heml/utils' // eslint-disable-line no-unused-vars
+import HEML, { createMetaElement } from '@heml/utils' // eslint-disable-line no-unused-vars
 
 let metaMap
 
-export default createElement('meta', {
+export default createMetaElement('meta', {
   attrs: true,
   parent: [ 'head' ],
 

--- a/packages/heml-elements/src/Preview.js
+++ b/packages/heml-elements/src/Preview.js
@@ -1,7 +1,7 @@
-import HEML, { createElement } from '@heml/utils' // eslint-disable-line no-unused-vars
+import HEML, { createMetaElement } from '@heml/utils' // eslint-disable-line no-unused-vars
 import Meta from './Meta'
 
-export default createElement('preview', {
+export default createMetaElement('preview', {
   parent: [ 'head' ],
   unique: true,
 

--- a/packages/heml-elements/src/Style.js
+++ b/packages/heml-elements/src/Style.js
@@ -1,4 +1,4 @@
-import HEML, { createElement } from '@heml/utils' // eslint-disable-line no-unused-vars
+import HEML, { createMetaElement } from '@heml/utils' // eslint-disable-line no-unused-vars
 import hemlstyles from '@heml/styles'
 import { castArray, isEqual, uniqWith, sortBy } from 'lodash'
 
@@ -8,7 +8,7 @@ const START_INLINE_CSS = `/*!***START:INLINE_CSS*****/`
 let styleMap
 let options
 
-export default createElement('style', {
+export default createMetaElement('style', {
   parent: [ 'head' ],
   attrs: [ 'for', 'heml-embed' ],
   defaultAttrs: {

--- a/packages/heml-elements/src/Style.js
+++ b/packages/heml-elements/src/Style.js
@@ -19,7 +19,7 @@ export default createMetaElement('style', {
     const $nodes = $.findNodes('style')
     const styles = nodesToStyles($nodes)
 
-    const { css: processedCss } = await hemlstyles(stylesToCss([...elementStyles, ...styles ]), options)
+    const { css: processedCss } = await hemlstyles(stylesToCss([ ...elementStyles, ...styles ]), options)
     const processedStyles = cssToStyles(processedCss)
 
     $nodes.forEach(($node) => $node.remove())
@@ -30,7 +30,6 @@ export default createMetaElement('style', {
     return true
   }
 })
-
 
 /**
  * Generates the options object to be passed to hemlstyles
@@ -64,7 +63,7 @@ function buildOptions ({ $, elements }) {
  * @param  {Object}        globals
  * @return {Array[Object]}         an Array of style objects
  */
-function gatherElementStyles({ elements }) {
+function gatherElementStyles ({ elements }) {
   return compact(flatMap(elements, (element) => element.css && JSON.parse(element.css(StyleObjectElement))))
 }
 
@@ -82,7 +81,7 @@ const StyleObjectElement = createElement('style-object', (attrs, contents) => {
  * @param  {Array[Cheerio]} $nodes
  * @return {Array[Object]}
  */
-function nodesToStyles($nodes) {
+function nodesToStyles ($nodes) {
   return $nodes.map(($node) => {
     return { css: $node.html(), embed: $node.is('[heml-embed]') }
   })
@@ -93,11 +92,21 @@ function nodesToStyles($nodes) {
  * @param  {Array[Object]} styles
  * @return {String}
  */
-function stylesToCss(styles) {
+function stylesToCss (styles) {
   styles = uniqWith(styles, isEqual)
 
-  return styles.reduce((fullCss, { embed, css }) => fullCss += embed ?
-    `${COMMENT_EMBED_CSS}${css}` : `${COMMENT_INLINE_CSS}${css}`, '')
+  let lastEmbed
+  let fullCss = ''
+  for (let { embed, css } of styles) {
+    if (lastEmbed !== embed) {
+      lastEmbed = embed
+      fullCss += embed ? COMMENT_EMBED_CSS : COMMENT_INLINE_CSS
+    }
+
+    fullCss += css
+  }
+
+  return fullCss
 }
 
 /**
@@ -105,7 +114,7 @@ function stylesToCss(styles) {
  * @param  {String}        css    a string of CSS
  * @return {Array[Object]}        styles
  */
-function cssToStyles(css) {
+function cssToStyles (css) {
   const parts = compact(css.split(COMMENT_REGEX))
 
   return parts.reduce((styles, value) => {
@@ -126,7 +135,7 @@ function cssToStyles(css) {
  * @param  {Array[Object]} styles
  * @return {Array[String]}
  */
-function stylesToTags(styles) {
+function stylesToTags (styles) {
   return styles.map(({ embed, css }) => {
     return `<style ${embed ? 'data-embed' : ''}>${css}</style>\n`
   })

--- a/packages/heml-elements/src/Style.js
+++ b/packages/heml-elements/src/Style.js
@@ -1,124 +1,116 @@
 import HEML, { createMetaElement } from '@heml/utils' // eslint-disable-line no-unused-vars
 import hemlstyles from '@heml/styles'
-import { castArray, isEqual, uniqWith, sortBy } from 'lodash'
+import escape from 'escape-string-regexp'
+import { castArray, isEqual, uniqWith, compact } from 'lodash'
 
-const START_EMBED_CSS = `/*!***START:EMBED_CSS*****/`
-const START_INLINE_CSS = `/*!***START:INLINE_CSS*****/`
-
-let styleMap
-let options
+const COMMENT_EMBED_CSS = `/*!***EMBED_CSS*****/`
+const COMMENT_INLINE_CSS = `/*!***INLINE_CSS*****/`
+const COMMENT_REGEX = new RegExp(`(${escape(COMMENT_EMBED_CSS)}|${escape(COMMENT_INLINE_CSS)})`)
 
 export default createMetaElement('style', {
   parent: [ 'head' ],
-  attrs: [ 'for', 'heml-embed' ],
-  defaultAttrs: {
-    'heml-embed': false,
-    'for': 'global'
-  },
+  attrs: [ 'heml-embed' ],
+  defaultAttrs: { 'heml-embed': false },
 
-  preRender ({ $, elements }) {
-    styleMap = new Map([ [ 'global', [] ] ])
-    options = {
-      plugins: [],
-      elements: {},
-      aliases: {}
-    }
+  async preRender (globals) {
+    const { $ } = globals
+    const options = buildOptions(globals)
+    const $nodes = $.findNodes('style')
+    const styles = nodesToStyles($nodes)
 
-    for (let element of elements) {
-      if (element.postcss) {
-        options.plugins = options.plugins.concat(castArray(element.postcss))
-      }
+    const { css: processedCss } = await hemlstyles(stylesToCss(styles), options)
+    const processedStyles = cssToStyles(processedCss)
 
-      if (element.rules) {
-        options.elements[element.tagName] = element.rules
-      }
-
-      options.aliases[element.tagName] = $.findNodes(element.tagName)
-    }
+    $nodes.forEach(($node) => $node.remove())
+    $('head').append(stylesToTags(processedStyles))
   },
 
   render (attrs, contents) {
-    if (!styleMap.get(attrs.for)) {
-      styleMap.set(attrs.for, [])
-    }
-
-    styleMap.get(attrs.for).push({
-      embed: !!attrs['heml-embed'],
-      ignore: !!attrs['heml-ignore'],
-      css: contents
-    })
-
-    return false
-  },
-
-  async flush () {
-    /**
-     * reverse the styles so they fall in an order that mirrors their position
-     * - they get rendered bottom to top - should be styled top to bottom
-     *
-     * the global styles should always be rendered last
-     */
-    const globalStyles = styleMap.get('global')
-    styleMap.delete('global')
-    styleMap = new Map([...styleMap].reverse())
-    styleMap.set('global', globalStyles)
-
-    let ignoredCSS = []
-    let fullCSS = ''
-
-    /** combine the non-ignored css to be combined */
-    for (let [ element, styles ] of styleMap) {
-      styles = uniqWith(styles, isEqual)
-      styles = element === 'global' ? styles : sortBy(styles, ['embed', 'css'])
-
-      styles.forEach(({ ignore, embed, css }) => {
-        /** replace the ignored css with placeholders that will be swapped later */
-        if (ignore) {
-          ignoredCSS.push({ embed, css })
-          fullCSS += ignoreComment(ignoredCSS.length - 1)
-        } else if (embed) {
-          fullCSS += `${START_EMBED_CSS}${css}`
-        } else {
-          fullCSS += `${START_INLINE_CSS}${css}`
-        }
-      })
-    }
-
-    let { css: processedCss } = await hemlstyles(fullCSS, options)
-
-    /** put the ignored css back in */
-    ignoredCSS.forEach(({ embed, css }, index) => {
-      processedCss = processedCss.replace(ignoreComment(index), embed ? `${START_EMBED_CSS}${css}` : `${START_INLINE_CSS}${css}`)
-    })
-
-    /** split on the dividers and map it so each part starts with INLINE or EMBED */
-    let processedCssParts = processedCss.split(/\/\*!\*\*\*START:/g).splice(1).map((css) => css.replace(/_CSS\*\*\*\*\*\//, ''))
-
-    /** build the html */
-    let html = ''
-    let lastType = null
-
-    for (let cssPart of processedCssParts) {
-      const css = cssPart.replace(/^(EMBED|INLINE)/, '')
-      const type = cssPart.startsWith('EMBED') ? 'EMBED' : 'INLINE'
-
-      if (type === lastType) {
-        html += css
-      } else {
-        lastType = type
-        html += `${html === '' ? '' : '</style>'}\n<style${type === 'EMBED' ? ' data-embed' : ''}>${css}\n`
-      }
-    }
-
-    html += '</style>'
-
-    /** reset the styles and options */
-    styleMap = options = null
-
-    return html
+    return true
   }
 })
 
-function ignoreComment (index) {
-  return `/*!***IGNORE_${index}*****/`
+
+/**
+ * Generates the options object to be passed to hemlstyles
+ * @param  {Cheerio} $        A cheerio instance
+ * @param  {Array}   elements an array of HEML elements
+ * @return {Object}           options for hemlstyles
+ */
+function buildOptions ({ $, elements }) {
+  const options = {
+    plugins: [],
+    elements: {},
+    aliases: {}
+  }
+
+  for (let element of elements) {
+    if (element.postcss) {
+      options.plugins = [ options.plugins, ...castArray(element.postcss) ]
+    }
+
+    if (element.rules) {
+      options.elements[element.tagName] = element.rules
+    }
+
+    options.aliases[element.tagName] = $.findNodes(element.tagName)
+  }
+
+  return options
+}
+
+/**
+ * Converts an array of $nodes into style objects
+ * scope = { embed: Boolean, css: String }
+ * @param  {Array[Cheerio]} $nodes
+ * @return {Array[Object]}
+ */
+function nodesToStyles($nodes) {
+  return $nodes.map(($node) => {
+    return { css: $node.html(), embed: $node.is('[heml-embed]') }
+  })
+}
+
+/**
+ * Converts an array of style objects into a single string to be processed by hemlstyles
+ * @param  {Array[Object]} styles
+ * @return {String}
+ */
+function stylesToCss(styles) {
+  styles = uniqWith(styles, isEqual)
+
+  return styles.reduce((fullCss, { embed, css }) => fullCss += embed ?
+    `${COMMENT_EMBED_CSS}${css}` : `${COMMENT_INLINE_CSS}${css}`, '')
+}
+
+/**
+ * Converts a css string into  array of style objects
+ * @param  {String}          css
+ * @return {Array[Object]}   styles
+ */
+function cssToStyles(css) {
+  const parts = compact(css.split(COMMENT_REGEX))
+
+  return parts.reduce((styles, value) => {
+    if (value === COMMENT_EMBED_CSS) {
+      return [ ...styles, { embed: true, css: '' } ]
+    } else if (value === COMMENT_INLINE_CSS) {
+      return [ ...styles, { embed: false, css: '' } ]
+    } else {
+      styles[styles.length - 1].css += value
+
+      return styles
+    }
+  }, []).filter((style) => style.css.length > 0)
+}
+
+/**
+ * Convert style objects into html tags
+ * @param  {Array[Object]} styles
+ * @return {Array[String]}
+ */
+function stylesToTags(styles) {
+  return styles.map(({ embed, css }) => {
+    return `<style ${embed ? 'data-embed' : ''}>${css}</style>\n`
+  })
 }

--- a/packages/heml-elements/src/Subject.js
+++ b/packages/heml-elements/src/Subject.js
@@ -1,7 +1,7 @@
-import HEML, { createElement } from '@heml/utils' // eslint-disable-line no-unused-vars
+import HEML, { createMetaElement } from '@heml/utils' // eslint-disable-line no-unused-vars
 import Meta from './Meta'
 
-export default createElement('subject', {
+export default createMetaElement('subject', {
   parent: [ 'head' ],
   unique: true,
 

--- a/packages/heml-render/src/index.js
+++ b/packages/heml-render/src/index.js
@@ -1,4 +1,4 @@
-import { filter, difference, keyBy, first } from 'lodash'
+import { filter, keyBy, first } from 'lodash'
 import renderElement from './renderElement'
 
 export { renderElement }
@@ -84,7 +84,7 @@ async function renderElements (elements, globals) {
  * @param  {Array[Cheerio]} $nodes
  * @param  {Object}         globals { $, elements }
  */
-async function renderNodes($nodes, globals) {
+async function renderNodes ($nodes, globals) {
   const { elements } = globals
   const elementMap = keyBy(elements, 'tagName')
 
@@ -99,13 +99,12 @@ async function renderNodes($nodes, globals) {
   }
 }
 
-
 /**
  * renders a single $node of the given element
  * @param  {Cheerio} $node
  * @param  {Object}  element
  */
-async function renderNode($node, element) {
+async function renderNode ($node, element) {
   const contents = $node.html()
   const attrs = $node[0].attribs
 

--- a/packages/heml-render/src/index.js
+++ b/packages/heml-render/src/index.js
@@ -67,9 +67,8 @@ async function renderElements (elements, globals) {
   renderNodes($nodes, globals)
 }
 
-
 /**
- * renders the given element $nodes
+ * renders the given array of $nodes
  * @param  {Array[Cheerio]} $nodes
  * @param  {Object}         globals { $, elements }
  */
@@ -80,14 +79,25 @@ function renderNodes($nodes, globals) {
   for (let $node of $nodes) {
     const tagName = $node.prop('tagName').toLowerCase()
 
-    if (!elementMap[tagName]) { return }
+    if (!elementMap[tagName]) { continue }
 
     const element = elementMap[tagName]
-    const contents = $node.html()
-    const attrs = $node[0].attribs
 
-    const renderedValue = await Promise.resolve(renderElement(element, attrs, contents))
-
-    $node.replaceWith(renderedValue.trim())
+    renderNode($node, element)
   }
+}
+
+
+/**
+ * renders a single $node of the given element
+ * @param  {Cheerio} $node
+ * @param  {Object}  element
+ */
+function renderNode($node, element) {
+  const contents = $node.html()
+  const attrs = $node[0].attribs
+
+  const renderedValue = await Promise.resolve(renderElement(element, attrs, contents))
+
+  $node.replaceWith(renderedValue.trim())
 }

--- a/packages/heml-render/src/index.js
+++ b/packages/heml-render/src/index.js
@@ -56,7 +56,6 @@ async function postRenderElements (elements, globals) {
  */
 async function renderElements (elements, globals) {
   const { $ } = globals
-  const elementMap = keyBy(elements, 'tagName')
   const metaTagNames = filter(elements, { parent: [ 'head' ] }).map(({ tagName }) => tagName)
   const nonMetaTagNames = difference(elements.map(({ tagName }) => tagName), metaTagNames)
 
@@ -65,8 +64,25 @@ async function renderElements (elements, globals) {
     ...$.findNodes(nonMetaTagNames).reverse() /** Render the elements last to first/outside to inside */
   ]
 
+  renderNodes($nodes, globals)
+}
+
+
+/**
+ * renders the given element $nodes
+ * @param  {Array[Cheerio]} $nodes
+ * @param  {Object}         globals { $, elements }
+ */
+function renderNodes($nodes, globals) {
+  const { elements } = globals
+  const elementMap = keyBy(elements, 'tagName')
+
   for (let $node of $nodes) {
-    const element = elementMap[$node.prop('tagName').toLowerCase()]
+    const tagName = $node.prop('tagName').toLowerCase()
+
+    if (!elementMap[tagName]) { return }
+
+    const element = elementMap[tagName]
     const contents = $node.html()
     const attrs = $node[0].attribs
 

--- a/packages/heml-utils/src/createMetaElement.js
+++ b/packages/heml-utils/src/createMetaElement.js
@@ -1,0 +1,18 @@
+import { defaults, isFunction } from 'lodash'
+import createElement from './createElement'
+
+export default function (name, element) {
+  if (!name || name.trim().length === 0) {
+    throw new Error(`When creating an element, you must set the name. ${name.trim().length === 0 ? 'An empty string' : `"${name}"`} was given.`)
+  }
+
+  if (isFunction(element)) {
+    element = { render: element }
+  }
+
+  element.meta = true
+
+  return createElement(name, element)
+}
+
+

--- a/packages/heml-utils/src/createMetaElement.js
+++ b/packages/heml-utils/src/createMetaElement.js
@@ -1,4 +1,4 @@
-import { defaults, isFunction } from 'lodash'
+import { isFunction } from 'lodash'
 import createElement from './createElement'
 
 export default function (name, element) {
@@ -14,5 +14,3 @@ export default function (name, element) {
 
   return createElement(name, element)
 }
-
-

--- a/packages/heml-utils/src/index.js
+++ b/packages/heml-utils/src/index.js
@@ -1,8 +1,9 @@
 import { renderElement } from '@heml/render'
 import cssGroups from 'css-groups'
 import createElement from './createElement'
+import createMetaElement from './createMetaElement'
 import HEMLError from './HEMLError'
 import transforms from './transforms'
 import condition from './condition'
 
-module.exports = { createElement, renderElement, HEMLError, cssGroups, transforms, condition }
+module.exports = { createElement, createMetaElement, renderElement, HEMLError, cssGroups, transforms, condition }

--- a/packages/heml/src/bin/heml.js
+++ b/packages/heml/src/bin/heml.js
@@ -27,7 +27,7 @@ cli
   .option('-v, --validate [level]', 'Sets the validation level', /^(none|soft|strict)$/i, 'soft')
   .action(build)
 
-if (args.length === 0 || !commands.includes(first(args)) && !first(args).startsWith('-')) {
+if (args.length === 0 || (!commands.includes(first(args)) && !first(args).startsWith('-'))) {
   cli.outputHelp()
 }
 


### PR DESCRIPTION
This PR moves the CSS processing to the preRender function. This will allow for a couple of different improvements in the near future. It will make optimizations easier and will let us improve the scoping (see #20) and make the selectors safer across all clients.

The main change for the usage (undocumented right now) you'll see if this takes away the ability to use the `Style` element in the render function and replaces it with a `css` function that passes a parameter `Style` that lets you add CSS in. 