### PR TITLE
add text Options to block element

### DIFF
--- a/packages/heml-elements/src/Block.js
+++ b/packages/heml-elements/src/Block.js
@@ -14,6 +14,7 @@ const {
   width,
   height,
   table,
+  text,
   box } = cssGroups
 
 export default createElement('block', {
@@ -28,7 +29,7 @@ export default createElement('block', {
 
     '.block__row': [ { '@pseudo': 'row' } ],
 
-    '.block__cell': [ { '@pseudo': 'cell' }, height, background, box, padding, border, borderRadius, 'vertical-align' ]
+    '.block__cell': [ { '@pseudo': 'cell' }, height, background, box, padding, border, borderRadius, text, 'vertical-align' ]
   },
 
   render (attrs, contents) {


### PR DESCRIPTION
This adds text styling options to block elements, you can now align right, center etc inside a block element. It's described in the docs but doesn't work.