### PR TITLE
DOCTYPE is not self-closing

### DIFF
--- a/packages/heml-elements/src/Heml.js
+++ b/packages/heml-elements/src/Heml.js
@@ -13,7 +13,7 @@ export default createElement('heml', {
 
   render (attrs, contents) {
     return ([
-      `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />`,
+      `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">`,
       <html {...attrs}>
         {contents}
       </html>])


### PR DESCRIPTION
We found out in our team that DOCTYPE is not self-closing when we tried to use a HTML => PDF converter that choked on the self-closing DOCTYPE that HEML generates.

https://stackoverflow.com/questions/19199106/why-isnt-doctype-self-closing